### PR TITLE
site.conf: Disable initramfs for rpi for now

### DIFF
--- a/conf/site.conf
+++ b/conf/site.conf
@@ -24,11 +24,20 @@ PACKAGE_FEED_URIS ??= "http://<FEEDSERVER>"
 # Enable serial console on Raspberry PI systems
 ENABLE_UART = "1"
 
+# disable emitting console getty when UART is disabled
+# by disabling ENABLE_UART, this can end up with messages
+# Getty spawning too fast...
+#
+#SERIAL_CONSOLE_rpi = ""
+
 # Enable initramfs in kernel for non-qemu machines
 INITRAMFS_IMAGE_BUNDLE = "1"
 INITRAMFS_IMAGE = "initramfs-image"
 INITRAMFS_IMAGE_BUNDLE_qemuall = ""
 INITRAMFS_IMAGE_qemuall = ""
+INITRAMFS_IMAGE_BUNDLE_rpi = ""
+INITRAMFS_IMAGE_rpi = ""
+
 IMAGE_BOOT_FILES_remove_sama5d27-som1-ek-sd = "${KERNEL_IMAGETYPE}"
 IMAGE_BOOT_FILES_append_sama5d27-som1-ek-sd = "\
     ${KERNEL_IMAGETYPE}-initramfs-${MACHINE}.bin;${KERNEL_IMAGETYPE} \
@@ -36,7 +45,7 @@ IMAGE_BOOT_FILES_append_sama5d27-som1-ek-sd = "\
 WKS_FILE_sama5d27-som1-ek-sd = "yoe-sdimage.wks"
 
 IMG_VERSION = "0.0.1"
-
+#INHERIT += "lto"
 #####################################################################
 # add project specific configuration below this line
 #####################################################################


### PR DESCRIPTION
rpi updater needs to be worked on yet
Document SERIAL_CONSOLE resetting, its needed when UART is disabled
Add LTO enabling knob in comments, since it needs meta-clang

Signed-off-by: Khem Raj <raj.khem@gmail.com>