### PR TITLE
documentation: fix typo in link to yocto docs

### DIFF
--- a/docs/conf-files.md
+++ b/docs/conf-files.md
@@ -21,4 +21,4 @@ The above configuration files are included into the build by the
 [bitbake.conf](https://github.com/YoeDistro/openembedded-core/blob/master/meta/conf/bitbake.conf#L744) file in the OpenEmbedded Core layer.
 
 For a full list of variables available in the OpenEmbedded build system, see the
-[Variables Glossary](https://www.yoctoproject.org/docs/lastest/mega-manual/mega-manual.html#ref-variables-glos).
+[Variables Glossary](https://www.yoctoproject.org/docs/latest/mega-manual/mega-manual.html#ref-variables-glos).


### PR DESCRIPTION
Great project! Just a little typo in link I noticed while reading your docs. 