### PR TITLE
raspberrypi0-wifi-envsetup.sh: add rpi0w support

### DIFF
--- a/raspberrypi0-wifi-envsetup.sh
+++ b/raspberrypi0-wifi-envsetup.sh
@@ -1,0 +1,1 @@
+envsetup.sh


### PR DESCRIPTION
This hardware is already supported by [meta-raspberrypi](https://github.com/agherzan/meta-raspberrypi), so supporting it here at least means adding a symlink.

It built and booted for me with no problems, although I have not yet tested any wireless functionality.