### PR TITLE
envsetup: Dockerize devtool

### DIFF
--- a/envsetup.sh
+++ b/envsetup.sh
@@ -515,6 +515,15 @@ bitbake() {
   fi
 }
 
+devtool() {
+  ulimit -n 4096
+  if [ -z $DOCKER_REPO ] || [ "$DOCKER_REPO" = "none" ]; then
+    ${OE_BASE}/sources/openembedded-core/scripts/devtool $@
+  else
+    dkr "${OE_BASE}/sources/openembedded-core/scripts/devtool $@"
+  fi
+}
+
 yoe_get_image_version() {
   echo $(read_var_from_conf 'IMG_VERSION')
 }


### PR DESCRIPTION
devtool, currently runs outside container, its better to run it inside
container when container is desired to be used. Helps in ensuring
consistency in build failures

Signed-off-by: Khem Raj <raj.khem@gmail.com>