### PR TITLE
envsetup.sh: Do not allocate pseudo TTY

### DIFF
--- a/envsetup.sh
+++ b/envsetup.sh
@@ -467,10 +467,12 @@ dkr() {
   check_docker || return 1
 
   CMD="$1"
+  PSEUDOTTY=""
 
   if [ -z "$CMD" ]; then
     echo "setting dkr action to shell"
     CMD="/bin/bash"
+    PSEUDOTTY="--tty"
   fi
 
   SSH_AUTH_DIR=~/
@@ -492,7 +494,7 @@ dkr() {
     SSH_AUTH_DIR=$(readlink -f $SSH_AUTH_SOCK)
   fi
 
-  docker run --rm -it \
+  docker run --rm -i ${PSEUDOTTY} --log-driver=none -a stdin -a stdout -a stderr \
     -v $(pwd):$(pwd) \
     -v ~/.ssh:/home/build/.ssh \
     -v ~/.gitconfig:/home/build/.gitconfig \


### PR DESCRIPTION
This fixes the deformed output with control characters and progress bar
expansions, output now looks like it is on interactive shells

To use docker run in a shell pipeline or under shell redirection
make run accept stdin and output to stdout and stderr appropriately

Signed-off-by: Khem Raj <raj.khem@gmail.com>