### PR TITLE
envsetup: Remove additional options to docker run

### DIFF
--- a/envsetup.sh
+++ b/envsetup.sh
@@ -467,12 +467,10 @@ dkr() {
   check_docker || return 1
 
   CMD="$1"
-  PSEUDOTTY=""
 
   if [ -z "$CMD" ]; then
     echo "setting dkr action to shell"
     CMD="/bin/bash"
-    PSEUDOTTY="--tty"
   fi
 
   SSH_AUTH_DIR=~/
@@ -494,7 +492,7 @@ dkr() {
     SSH_AUTH_DIR=$(readlink -f $SSH_AUTH_SOCK)
   fi
 
-  docker run --rm -i ${PSEUDOTTY} --log-driver=none -a stdin -a stdout -a stderr \
+  docker run --rm -it \
     -v $(pwd):$(pwd) \
     -v ~/.ssh:/home/build/.ssh \
     -v ~/.gitconfig:/home/build/.gitconfig \

--- a/envsetup.sh
+++ b/envsetup.sh
@@ -471,8 +471,9 @@ dkr() {
   if [ -z "$CMD" ]; then
     echo "setting dkr action to shell"
     CMD="/bin/bash"
+  else
+    shift
   fi
-
   SSH_AUTH_DIR=~/
 
   unset MAP_DL_DIR
@@ -502,8 +503,9 @@ dkr() {
     -v $SSH_AUTH_DIR:/ssh-agent \
     -e SSH_AUTH_SOCK=/ssh-agent \
     -e MACHINE=$MACHINE \
+    -w ${OE_BASE} \
     --user $(id -u):$(id -g) \
-    ${DOCKER_REPO} /bin/bash -c "cd $(pwd) && . envsetup.sh && $CMD $2 $3 $4 $5 $6 $7 $8"
+    ${DOCKER_REPO} /bin/bash -c ". envsetup.sh && $CMD $@"
 }
 
 bitbake() {

--- a/envsetup.sh
+++ b/envsetup.sh
@@ -479,15 +479,9 @@ dkr() {
   unset MAP_DL_DIR
   unset MAP_TMPDIR
   unset MAP_SSTATE_DIR
-  if [ -n "$CUSTOM_DL_DIR" ]; then
-    MAP_DL_DIR="-v $CUSTOM_DL_DIR:$CUSTOM_DL_DIR"
-  fi
-  if [ -n "$CUSTOM_TMPDIR" ]; then
-    MAP_TMPDIR="-v $CUSTOM_TMPDIR:$CUSTOM_TMPDIR"
-  fi
-  if [ -n "$CUSTOM_SSTATE_DIR" ]; then
-    MAP_SSTATE_DIR="-v $CUSTOM_SSTATE_DIR:$CUSTOM_SSTATE_DIR"
-  fi
+  MAP_TMPDIR="-v $(readlink -f $OE_BUILD_TMPDIR):$(readlink -f $OE_BUILD_TMPDIR)"
+  MAP_DL_DIR="-v $(readlink -f $OE_DL_DIR):$(readlink -f $OE_DL_DIR)"
+  MAP_SSTATE_DIR="-v $(readlink -f $OE_SSTATE_DIR):$(readlink -f $OE_SSTATE_DIR)"
 
   if [ -n "$SSH_AUTH_SOCK" ]; then
     SSH_AUTH_DIR=$(readlink -f $SSH_AUTH_SOCK)

--- a/envsetup.sh
+++ b/envsetup.sh
@@ -474,6 +474,12 @@ dkr() {
   else
     shift
   fi
+  if [ "$DOCKER_PSEUDO_TTY" = "no" ]; then
+    PSEUDO_TTY=""
+  else
+    PSEUDO_TTY="-t"
+  fi
+
   SSH_AUTH_DIR=~/
 
   unset MAP_DL_DIR
@@ -487,7 +493,7 @@ dkr() {
     SSH_AUTH_DIR=$(readlink -f $SSH_AUTH_SOCK)
   fi
 
-  docker run --rm -it \
+  docker run --rm -i $PSEUDO_TTY \
     -v $(pwd):$(pwd) \
     -v ~/.ssh:/home/build/.ssh \
     -v ~/.gitconfig:/home/build/.gitconfig \

--- a/local.sh.example
+++ b/local.sh.example
@@ -18,3 +18,10 @@
 
 # configure docker container to run bitbake in
 #export DOCKER_REPO=yoedistro/yoe-build:buster
+
+# Flag to control docker launch with pseudo-tty
+# when output is piped or redirected to files then
+# then docker should be launched without tty
+# otherwise it will emit all control characters into
+# redirected log files, default is 'yes'
+#export DOCKER_PSEUDO_TTY=no


### PR DESCRIPTION
Forwarding stdin/stdout/stderr causes regression in disaplay in
interactive mode where progress bar is not displayed. Disable it for now.

Signed-off-by: Khem Raj <raj.khem@gmail.com>