### PR TITLE
envsetup: Set umark 022

### DIFF
--- a/envsetup.sh
+++ b/envsetup.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # the following can be used inside functions that return strings to display
 # messages on console
+umask 022
+
 echoerr() {
   echo $@ >&2
 }


### PR DESCRIPTION
Ensure that mask for file creation is set so that go modules do not end
up being readonly in work-shared ( GOPATH ), if they become readonly
inside builddir, they can not be deleted without chaging perms or
applying sudo permissions

Signed-off-by: Khem Raj <raj.khem@gmail.com>