### PR TITLE
yoe.inc: Increase Qemu memory and enable smp

### DIFF
--- a/sources/meta-yoe/conf/distro/yoe.inc
+++ b/sources/meta-yoe/conf/distro/yoe.inc
@@ -153,6 +153,14 @@ SWUPDATE_INIT = "tiny"
 # we want to have boot + rootfs ( that can grow )
 WKS_FILE_beaglebone = "sdimage-bootpart.wks"
 
+# Use 1GB DRAM for QEMU machines, helps in running tests
+QB_MEM = "-m 1024"
+
+# Enable SMP in QEMU, helps in running tests a bit quicker
+QB_NRCPUS ?= "2"
+QB_CPU_append = " -smp ${QB_NRCPUS}"
+QB_CPU_KVM_append = " -smp ${QB_NRCPUS}"
+
 INHERIT += "blacklist"
 PNBLACKLIST[build-appliance-image] = "tries to include whole downloads directory in /home/builder/poky :/"
 PNBLACKLIST[smartrefrigerator] = "Needs porting to QT > 5.6"


### PR DESCRIPTION
This helps in running ptests in reasonable time
when we use 1G for RAM and use atleast 2 cores

Signed-off-by: Khem Raj <raj.khem@gmail.com>