### PR TITLE
envsetup: Fix bash syntax error

### DIFF
--- a/envsetup.sh
+++ b/envsetup.sh
@@ -507,7 +507,7 @@ dkr() {
   GGID=$(id -g)
   UUID=$(id -u)
   UID_ARGS=""
-  if [ "$DOCKER" = "podman"]; then
+  if [ "$DOCKER" = "podman" ]; then
       # Running with namespace and overlay-fs labelling enabled introduces a
       # significant delay in podman startup when the build directory contains
       # giga-bytes of data, so for now, disable default namespacing and provide


### PR DESCRIPTION
A space is needed before the ]. Regression introduced in
9c46104bf9177e5d9ce7892c0b2097a902bb8c1f, my apologies ;)