### PR TITLE
Add note regarding memory requirement.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ port forwarding to work on docker
 
 - Archlinux based sytems - `sudo pacman -S iptables-nft`
 
+- On host systems with 8G RAM or less it will be necessary to ensure a swap file of 8G.
+
 ## Workspace Setup
 
 1. `git clone --recurse-submodules -j8 -b master git://github.com/YoeDistro/yoe-distro.git yoe`


### PR DESCRIPTION
On a quad core system with 8G memory and 2g swap file the build crashed the computer repeatedly during Clang compilation. Altering thread count had no effect. Increasing swap file size to 8G allowed the build to succeed with all threads.

I added a note to the README in the hope it will help others. Thanks for Yoe Distro!