### PR TITLE
skip the internet connection sanity check during bitbake

### DIFF
--- a/envsetup.sh
+++ b/envsetup.sh
@@ -231,6 +231,9 @@ TMPDIR = "${OE_BUILD_TMPDIR}"
 # Go through the Firewall
 #HTTP_PROXY        = "http://${PROXYHOST}:${PROXYPORT}/"
 
+#Skip the internet connection check
+CONNECTIVITY_CHECK_URIS = ""
+
 MACHINE ?= "$MACHINE"
 _EOF
 


### PR DESCRIPTION
The CONNECTIVITY_CHECKS_URI empty will skip the internet connection avoiding sanity check the error.

