### PR TITLE
yoe.inc: Use oe-core provided CONNECTIVITY_CHECK_URIS

### DIFF
--- a/sources/meta-yoe/conf/distro/yoe.inc
+++ b/sources/meta-yoe/conf/distro/yoe.inc
@@ -37,12 +37,6 @@ https://.*/.*    http://downloads.yoctoproject.org/mirror/sources/ \n"
 # Allow reusing DL_DIR from the current build as a mirror for other builds.
 BB_GENERATE_MIRROR_TARBALLS = "1"
 
-# The CONNECTIVITY_CHECK_URI's are used to test whether we can succesfully
-# fetch from the network (and warn you if not). To disable the test set
-# the variable to be empty.
-# Git example url: git://git.yoctoproject.org/yocto-firewall-test;protocol=git;rev=master
-CONNECTIVITY_CHECK_URIS ?= "https://www.example.com/"
-
 PRSERV_HOST = "localhost:0"
 TCLIBCAPPEND = ""
 


### PR DESCRIPTION
This points to yoctoproject provided URL now, which is sane because we
use yoctoproject premirrors in build, so it will be very broken build if
yp org is not reachable.

Signed-off-by: Khem Raj <raj.khem@gmail.com>