### PR TITLE
ci.yml: Use poky dir for finding sstate-cache-management.sh

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,4 +58,4 @@ jobs:
           /bin/bash -c ". ./qemuarm64-envsetup.sh && resulttool report build/tmp/log/oeqa"
       - name: Clean shared state
         run: |
-          /bin/bash -c ". ./qemuarm64-envsetup.sh && ./sources/openembedded-core/scripts/sstate-cache-management.sh -d -y"
+          /bin/bash -c ". ./qemuarm64-envsetup.sh && ./sources/poky/scripts/sstate-cache-management.sh -d -y"

--- a/docs/conf-files.md
+++ b/docs/conf-files.md
@@ -20,8 +20,8 @@ files include:
   add.
 
 The above configuration files are included into the build by the
-[bitbake.conf](https://github.com/YoeDistro/openembedded-core/blob/master/meta/conf/bitbake.conf#L744)
-file in the OpenEmbedded Core layer.
+[bitbake.conf](https://github.com/YoeDistro/poky/blob/master/meta/conf/bitbake.conf#L744)
+file in the OE Core layer provided by poky.
 
 For a full list of variables available in the OpenEmbedded build system, see the
 [Variables Glossary](https://www.yoctoproject.org/docs/latest/mega-manual/mega-manual.html#ref-variables-glos).

--- a/docs/gcc.md
+++ b/docs/gcc.md
@@ -15,7 +15,7 @@ a package manager such as opkg.
 
 - `packagegroup-core-buildessential` - this is most often what you need and is
   very similiar to the build-essential package on Debian/Ubuntu.
-  [recipe](https://github.com/YoeDistro/openembedded-core/blob/master/meta/recipes-core/packagegroups/packagegroup-core-buildessential.bb)
+  [recipe](https://github.com/YoeDistro/poky/blob/master/meta/recipes-core/packagegroups/packagegroup-core-buildessential.bb)
 - `packagegroup-self-hosted` - a much more extensive list of packages that
   includes what is in buildessential, plus a lot more.
-  [recipe](https://github.com/YoeDistro/openembedded-core/blob/master/meta/recipes-core/packagegroups/packagegroup-self-hosted.bb)
+  [recipe](https://github.com/YoeDistro/poky/blob/master/meta/recipes-core/packagegroups/packagegroup-self-hosted.bb)


### PR DESCRIPTION
We changed to use poky for core layer

Signed-off-by: Khem Raj <raj.khem@gmail.com>