### PR TITLE
yoe: Use gnu objcopy for kernel

### DIFF
--- a/sources/meta-yoe/conf/distro/yoe.inc
+++ b/sources/meta-yoe/conf/distro/yoe.inc
@@ -164,6 +164,10 @@ OPKGBUILDCMD = 'opkg-build -Z zstd -a "${XZ_DEFAULTS}"'
 # Use gcc for perf temporarily, until oe-core gets it
 TOOLCHAIN:pn-perf = "gcc"
 
+# Subprocess output:arm-yoe-linux-llvm-objcopy: error: Link field value 22 in section .rel.dyn is not a symbol table
+OBJCOPY:pn-linux-raspberrypi:toolchain-clang = "${HOST_PREFIX}objcopy"
+OBJCOPY:pn-linux-ti-staging:toolchain-clang = "${HOST_PREFIX}objcopy"
+
 SKIP_RECIPE[build-appliance-image] = "tries to include whole downloads directory in /home/builder/poky :/"
 SKIP_RECIPE[smartrefrigerator] = "Needs porting to QT > 5.6"
 SKIP_RECIPE[qmlbrowser] = "Needs porting to QT > 5.6"


### PR DESCRIPTION
llvm objcopy does not work
Subprocess output:aarch64-yoe-linux-llvm-objcopy: error: Link field value 31 in section .rela.dyn is not a symbol table

Signed-off-by: Khem Raj <raj.khem@gmail.com>