### PR TITLE
simpleiot: Use host c++ compiler when needed

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -35,6 +35,7 @@ jobs:
           echo TOOLCHAIN = \"clang\" >> conf/local.conf
           echo BB_NUMBER_THREADS = \"16\" >> conf/local.conf
           echo PARALLEL_MAKE = \"-j 32\" >> conf/local.conf
+          echo ZSTD_THREADS = \"8\" >> conf/local.conf
           echo XZ_THREADS = \"8\" >> conf/local.conf
           echo XZ_MEMLIMIT = \"20%\" >> conf/local.conf
           /bin/bash -c "sed -i -e 's/PACKAGE_FEED_URI.*$//' conf/site.conf"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,6 +42,7 @@ jobs:
           echo TOOLCHAIN = \"clang\" >> conf/local.conf
           echo BB_NUMBER_THREADS = \"16\" >> conf/local.conf
           echo PARALLEL_MAKE = \"-j 32\" >> conf/local.conf
+          echo ZSTD_THREADS = \"8\" >> conf/local.conf
           echo XZ_THREADS = \"8\" >> conf/local.conf
           echo XZ_MEMLIMIT = \"20%\" >> conf/local.conf
           /bin/bash -c "sed -i -e 's/PACKAGE_FEED_URI.*$//' conf/site.conf"

--- a/sources/meta-yoe/conf/projects/qemucommon/config.conf
+++ b/sources/meta-yoe/conf/projects/qemucommon/config.conf
@@ -5,11 +5,13 @@ YOE_PROFILE = "yoe-glibc-systemd-wayland"
 # Add 4G space to QEMU image
 IMAGE_ROOTFS_EXTRA_SPACE:append = " + 4000000"
 # common
-TEST_SERVER_IP = "10.0.0.13"
+#TEST_SERVER_IP = "10.0.0.13"
 # QEMU
-TEST_TARGET_IP = "192.168.7.2"
+#TEST_TARGET_IP = "192.168.7.2"
 #TEST_QEMUBOOT_TIMEOUT = "100"
-TFTP_SERVER_IP = "10.0.0.13"
+#TEST_TARGET = "qemu"
+#TEST_TARGET = "simpleremote"
+#TFTP_SERVER_IP = "10.0.0.13"
 
 #INHERIT += "scan-build"
 SCAN_BUILD ?= ""
@@ -17,9 +19,6 @@ SCAN_BUILD:pn-openssl = "1"
 
 IMAGE_FSTYPES:append = " wic.xz wic.bmap tar.xz"
 IMAGE_FSTYPES:remove = "tar.bz2 tar.xz tar tar.gz wic.xz wic.bmap"
-
-TEST_TARGET = "qemu"
-TEST_TARGET = "simpleremote"
 # use kvm with x86/x86_64 qemu
 QEMU_USE_KVM = "1"
 # Launch vnc backend during testing

--- a/sources/meta-yoe/conf/projects/qemuriscv64/config.conf
+++ b/sources/meta-yoe/conf/projects/qemuriscv64/config.conf
@@ -5,11 +5,13 @@ YOE_PROFILE = "yoe-glibc-systemd-wayland"
 # Add 4G space to QEMU image
 IMAGE_ROOTFS_EXTRA_SPACE:append = " + 4000000"
 # common
-TEST_SERVER_IP = "10.0.0.13"
+#TEST_SERVER_IP = "10.0.0.13"
 # QEMU
-TEST_TARGET_IP = "192.168.7.2"
+#TEST_TARGET_IP = "192.168.7.2"
 #TEST_QEMUBOOT_TIMEOUT = "100"
-TFTP_SERVER_IP = "10.0.0.13"
+#TEST_TARGET = "qemu"
+#TEST_TARGET = "simpleremote"
+#TFTP_SERVER_IP = "10.0.0.13"
 
 #INHERIT += "scan-build"
 SCAN_BUILD ?= ""
@@ -17,9 +19,6 @@ SCAN_BUILD:pn-openssl = "1"
 
 IMAGE_FSTYPES:append = " wic.xz wic.bmap tar.xz"
 IMAGE_FSTYPES:remove = "tar.bz2 tar.xz tar tar.gz wic.xz wic.bmap"
-
-TEST_TARGET = "qemu"
-TEST_TARGET = "simpleremote"
 # use kvm with x86/x86_64 qemu
 QEMU_USE_KVM = "1"
 # Launch vnc backend during testing

--- a/sources/meta-yoe/recipes-siot/simpleiot/simpleiot_0.9.0.bb
+++ b/sources/meta-yoe/recipes-siot/simpleiot/simpleiot_0.9.0.bb
@@ -41,6 +41,8 @@ do_compile() {
     export GOARCH=${TARGET_GOARCH}
     export PATH=${GOPATH}/bin:$PATH
     export GOFLAGS="-modcacherw"
+    export CXX="${BUILD_CXX}"
+    export CXXFLAGS="${BUILD_CXXFLAGS}"
     . ${S}/envsetup.sh
     # FIXME: get elm cache in ~/.elm moved to work-shared
     rm -rf frontend/elm-stuff


### PR DESCRIPTION
Some node modules e.g. node-pty are needed on host side, therefore export host compiler to act as CXX, which will ensure it uses the native compiler instead of cross compiler during build.