### PR TITLE
beaglebone: Define virtual/gpudriver in settings

### DIFF
--- a/sources/meta-yoe/conf/projects/beaglebone/config.conf
+++ b/sources/meta-yoe/conf/projects/beaglebone/config.conf
@@ -18,10 +18,7 @@ IMAGE_BOOT_FILES:append = " ${KERNEL_IMAGETYPE}-initramfs-${MACHINE}.bin;${KERNE
 
 WKS_FILE:pn-yoe-installer-image = "yoe-installer.wks"
 
-PREFERRED_PROVIDER_virtual/egl = "ti-sgx-ddk-um"
-PREFERRED_PROVIDER_virtual/libgles1 = "ti-sgx-ddk-um"
-PREFERRED_PROVIDER_virtual/libgles2 = "ti-sgx-ddk-um"
-PREFERRED_PROVIDER_virtual/libgbm = "ti-sgx-ddk-um"
+PREFERRED_PROVIDER_virtual/gpudriver = "ti-sgx-ddk-km"
 DISTRO_FEATURES:remove = "vulkan x11"
 # ti-sgx-ddk-um has 19.1.6 version compatiblity of mesa and this
 # feature needs 21.1.x and renderer-gl needs GLES3 which is also


### PR DESCRIPTION
meta-ti has removed the explicit setting this [1]

[1] https://git.ti.com/cgit/arago-project/meta-ti/commit/?id=515a6c7e9b782a912c4814de98d8315a33e2099c