### PR TITLE
yoe: Always use psplash from core

### DIFF
--- a/sources/meta-yoe/conf/distro/yoe.inc
+++ b/sources/meta-yoe/conf/distro/yoe.inc
@@ -220,3 +220,6 @@ SKIP_RECIPE[python3-pyqtchart] = "needs python3-pyqt5 which needs reworked to wo
 RDEPENDS:packagegroup-meta-multimedia:remove:pn-packagegroup-meta-multimedia = "bigbuckbunny-1080p bigbuckbunny-480p bigbuckbunny-720p tearsofsteel-1080p"
 RDEPENDS:packagegroup-meta-oe-fortran-packages:remove:pn-packagegroup-meta-oe = "lapack octave suitesparse"
 RDEPENDS:packagegroup-meta-python3:remove:pn-packagegroup-meta-python = "python3-cvxopt"
+
+# remove once the definition in meta-raspberrypi is gone
+SPLASH = "${@bb.utils.contains("MACHINE_FEATURES", "screen", "psplash", "", d)}"


### PR DESCRIPTION
meta-rpi provides its own now defunct psplash-raspberrypi which causes builds to fail

ERROR: Nothing RPROVIDES 'psplash-raspberrypi' (but /home/khem/actions-runner-yoe/_work/yoe-distro/yoe-distro/sources/meta-yoe/recipes-core/images/yoe-qt5-image.bb RDEPENDS on or otherwise requires it)
NOTE: Runtime target 'psplash-raspberrypi' is unbuildable, removing...
Missing or unbuildable dependency chain was: ['psplash-raspberrypi']
ERROR: Required build target 'yoe-qt5-image' has no buildable providers.
Missing or unbuildable dependency chain was: ['yoe-qt5-image', 'psplash-raspberrypi']