### PR TITLE
envsetup.sh: docker: only use /dev/kvm if available

### DIFF
--- a/envsetup.sh
+++ b/envsetup.sh
@@ -602,6 +602,12 @@ dkr() {
       "
   fi
 
+  if [ -f /dev/kvm ]; then
+    DOCKER_ENABLE_KVM="--device /dev/kvm"
+  else
+    DOCKER_ENABLE_KVM=""
+  fi
+
   $DOCKER run --rm -i $PSEUDO_TTY \
     -v ${OE_BASE}:${OE_BASE} \
     -v ~/.ssh:/home/build/.ssh \
@@ -621,7 +627,7 @@ dkr() {
     $DOCKER_EXTRA_ARGS \
     --cap-add=NET_ADMIN \
     --device /dev/net/tun \
-    --device /dev/kvm \
+    ${DOCKER_ENABLE_KVM} \
     --device /dev/vhost-net \
     ${DOCKER_REPO} /bin/bash -c "$CMD"
 }


### PR DESCRIPTION
Hi all,
this is the easiest solution for #847. As requested it is transparent to the user. I can also make a function out of it if you prefer.  Should we warn the user about the consequences of not having kvm support?

Greets,
Bernhard