### PR TITLE
envsetup: /dev/kvm is  character device

### DIFF
--- a/envsetup.sh
+++ b/envsetup.sh
@@ -602,7 +602,7 @@ dkr() {
       "
   fi
 
-  if [ -f /dev/kvm ]; then
+  if [ -c /dev/kvm ]; then
     DOCKER_ENABLE_KVM="--device /dev/kvm"
   else
     DOCKER_ENABLE_KVM=""


### PR DESCRIPTION
-f will check for regular file type and check would fail regardless of it existing, therefore alter it to -c