### PR TITLE
projects: add intial raspberrypi5 support

### DIFF
--- a/conf/projects/rpi5/config.conf
+++ b/conf/projects/rpi5/config.conf
@@ -1,0 +1,71 @@
+MACHINE = "raspberrypi5"
+DISTRO = "yoe"
+# "yoe-<libc>-<init-system>-<windowing-system>"
+YOE_PROFILE = "yoe-glibc-systemd-wayland"
+
+# Acknowledge that Synaptics can revoke their license at any time on the
+# Rapsberry pi firmware
+LICENSE_FLAGS_ACCEPTED += "\
+    synaptics-killswitch \
+    nonfree_chexquest3 \
+    nonfree_chexquest-galactic-conflict \
+    "
+# Enable serial console on Raspberry PI systems
+ENABLE_UART = "1"
+
+ENABLE_I2C = "1"
+
+DISABLE_RPI_BOOT_LOGO = "1"
+
+# Disable rpi raimbow screen
+DISABLE_SPLASH = "1"
+
+IMAGE_FSTYPES = "wic.xz wic.bmap ext4.xz tar.xz"
+# Yoe Updater Supported Machines ( RPI, beaglebone, C4, SAMA5D27 for now )
+INITRAMFS_IMAGE_BUNDLE = "1"
+WKS_FILE = "yoe-sdimage.wks"
+# Use yoe-initramfs-image for initramfs
+INITRAMFS_IMAGE = "yoe-initramfs-image"
+# Use kernel+initramfs image to boot
+IMAGE_BOOT_FILES:remove = "${KERNEL_IMAGETYPE}"
+IMAGE_BOOT_FILES:append = " ${KERNEL_IMAGETYPE}-initramfs-${MACHINE}.bin;${KERNEL_IMAGETYPE}"
+
+# rpi (when not using u-boot )
+IMAGE_BOOT_FILES:remove = "${KERNEL_IMAGETYPE};${SDIMG_KERNELIMAGE}"
+IMAGE_BOOT_FILES:remove = "${KERNEL_IMAGETYPE}-initramfs-${MACHINE}.bin;${KERNEL_IMAGETYPE}"
+IMAGE_BOOT_FILES:append = " ${KERNEL_IMAGETYPE}-initramfs-${MACHINE}.bin;${SDIMG_KERNELIMAGE}"
+
+# Subprocess output:arm-yoe-linux-llvm-objcopy: error: Link field value 22 in section .rel.dyn is not a symbol table
+OBJCOPY:pn-linux-raspberrypi:toolchain-clang = "${HOST_PREFIX}objcopy"
+
+PACKAGECONFIG:pn-wpebackend-rdk:rpi = "rpi"
+# Needed for Running bitbake -ctestimage <image>
+TEST_TARGET_IP = "10.0.0.47"
+TEST_SERVER_IP = "10.0.0.13"
+TEST_TARGET = "simpleremote"
+IMG_VERSION = "0.0.1"
+#####################################################################
+# add project specific configuration below this line
+#####################################################################
+PACKAGECONFIG:pn-wpebackend-rdk = "rpi"
+# Use fkms for eglfs on RPI4 this enables both console display & graphics (for EGLFS)
+# Otherwise use full kms
+VC4DTBO = "${@bb.utils.contains('DISTRO_FEATURES', 'x11 wayland', 'vc4-kms-v3d', 'vc4-fkms-v3d', d)}"
+#require conf/distro/include/lto.inc
+#DISTRO_FEATURES:append = " lto"
+
+# Setting a user/password in system
+#INHERIT += "extrausers"
+#EXTRA_USERS_PARAMS += "\
+#    useradd admin; \
+#    usermod -p '$(openssl passwd -6 myrootpassword)' admin; \
+#    usermod -a -G adm admin; \
+#    usermod -a -G video admin; \
+#    usermod -a -G audio admin; \
+#    usermod -a -G systemd-journal admin; \
+#"
+#EXTRA_IMAGE_FEATURES:remove = "debug-tweaks"
+
+# For running oe-selftest uncomment below lines
+#USER_CLASSES:remove = "buildhistory"
+#PRSERV_HOST = ""

--- a/conf/projects/rpi5/layers.conf
+++ b/conf/projects/rpi5/layers.conf
@@ -1,0 +1,24 @@
+BBPATH = "${TOPDIR}"
+BBFILES ?= ""
+
+BBLAYERS = "\
+    ${TOPDIR}/sources/meta-yoe \
+    \
+    ${TOPDIR}/sources/meta-raspberrypi \
+    \
+    ${TOPDIR}/sources/meta-clang \
+    ${TOPDIR}/sources/meta-qt6 \
+    \
+    ${TOPDIR}/sources/meta-openembedded/meta-filesystems \
+    ${TOPDIR}/sources/meta-openembedded/meta-gnome \
+    ${TOPDIR}/sources/meta-openembedded/meta-initramfs \
+    ${TOPDIR}/sources/meta-openembedded/meta-multimedia \
+    ${TOPDIR}/sources/meta-openembedded/meta-networking \
+    ${TOPDIR}/sources/meta-openembedded/meta-oe \
+    ${TOPDIR}/sources/meta-openembedded/meta-perl \
+    ${TOPDIR}/sources/meta-openembedded/meta-python \
+    ${TOPDIR}/sources/meta-openembedded/meta-webserver \
+    ${TOPDIR}/sources/meta-openembedded/meta-xfce \
+    \
+    ${TOPDIR}/sources/poky/meta \
+"


### PR DESCRIPTION
Currently, meta-raspberrypi only has one machine which is 64-bit.