### PR TITLE
Add support for Intel x86-64

### DIFF
--- a/conf/projects/intel-x86-64/config.conf
+++ b/conf/projects/intel-x86-64/config.conf
@@ -1,0 +1,3 @@
+MACHINE = "intel-x86-64"
+DISTRO = "yoe"
+YOE_PROFILE = "yoe-glibc-systemd-wayland"

--- a/conf/projects/intel-x86-64/layers.conf
+++ b/conf/projects/intel-x86-64/layers.conf
@@ -1,0 +1,18 @@
+BBPATH = "${TOPDIR}"
+BBFILES ?= ""
+
+BBLAYERS = "\
+    ${TOPDIR}/sources/meta-yoe \
+    ${TOPDIR}/sources/meta-intel \
+    ${TOPDIR}/sources/meta-openembedded/meta-filesystems \
+    ${TOPDIR}/sources/meta-openembedded/meta-gnome \
+    ${TOPDIR}/sources/meta-openembedded/meta-initramfs \
+    ${TOPDIR}/sources/meta-openembedded/meta-multimedia \
+    ${TOPDIR}/sources/meta-openembedded/meta-networking \
+    ${TOPDIR}/sources/meta-openembedded/meta-oe \
+    ${TOPDIR}/sources/meta-openembedded/meta-perl \
+    ${TOPDIR}/sources/meta-openembedded/meta-python \
+    ${TOPDIR}/sources/meta-openembedded/meta-webserver \
+    ${TOPDIR}/sources/meta-openembedded/meta-xfce \
+    ${TOPDIR}/sources/poky/meta \
+"

--- a/docs/yoe-projects.md
+++ b/docs/yoe-projects.md
@@ -46,6 +46,7 @@ Currently these projects are supported.
 - rpi4-64
 - var-som-mx8
 - visionfive2
+- intel-x86-64
 
 ## Converting a project
 


### PR DESCRIPTION
Related to #950

Add support for Intel x86_64 architecture.

* Add `conf/projects/intel-x86-64/config.conf` with machine, distro, and profile settings.
* Add `conf/projects/intel-x86-64/layers.conf` with necessary layers for Intel x86_64 hardware.
* Update `docs/yoe-projects.md` to include the new Intel x86_64 project in the list of supported projects.

