### PR TITLE
yoe: Fix yoe updater for EFI switch

### DIFF
--- a/conf/projects/visionfive2/config.conf
+++ b/conf/projects/visionfive2/config.conf
@@ -14,8 +14,8 @@ WKS_FILE:yoe = "yoe-visionfive2-sdimage.wks"
 # Use yoe-initramfs-image for initramfs
 INITRAMFS_IMAGE = "yoe-initramfs-image"
 # Use kernel+initramfs image to boot
-IMAGE_BOOT_FILES:remove = "${KERNEL_IMAGETYPE}"
-IMAGE_BOOT_FILES:append = " ${KERNEL_IMAGETYPE}-${INITRAMFS_IMAGE}-${MACHINE}-${MACHINE};${KERNEL_IMAGETYPE}"
+#IMAGE_BOOT_FILES:remove = "${KERNEL_IMAGETYPE}"
+#IMAGE_BOOT_FILES:append = " ${KERNEL_IMAGETYPE}-${INITRAMFS_IMAGE}-${MACHINE}-${MACHINE};${KERNEL_IMAGETYPE}"
 
 # Needed for Running bitbake -ctestimage <image>
 TEST_TARGET_IP = "10.0.0.86"

--- a/sources/meta-yoe/recipes-core/images/machines/visionfive2.inc
+++ b/sources/meta-yoe/recipes-core/images/machines/visionfive2.inc
@@ -14,8 +14,7 @@ ROOTFS_ARTEFACTS = "rootfs.ext4.xz"
 
 BOOTLOADER_ARTEFACTS = "\
     fw_payload.bin \
-    boot.scr.uimg \
-    vf2_uEnv.txt \
+    grub-efi-bootriscv64.efi \
     "
 
 # Anything that is not mentioned above but it is created during updater artifacts creation e.g.
@@ -42,8 +41,6 @@ do_updater() {
             install -D ${DEPLOY_DIR_IMAGE}/`basename $f` $f
         done
         # Match kernel image with wic
-        rm ${KERNEL_IMAGETYPE}
-        install ${DEPLOY_DIR_IMAGE}/${KERNEL_IMAGE} ${KERNEL_IMAGETYPE}
         sha256sum ${UPDATE_IMAGES}  > update.sha256
         rm -rf ${TOPDIR}/deploy/${UPDATE_IMAGE_NAME}_${IMG_VERSION}.upd
         ls ${UPDATE_IMAGES_} | cpio -ov -H newc > ${TOPDIR}/deploy/${UPDATE_IMAGE_NAME}_${IMG_VERSION}.upd

--- a/sources/meta-yoe/recipes-support/updater/files/visionfive2/platform
+++ b/sources/meta-yoe/recipes-support/updater/files/visionfive2/platform
@@ -5,14 +5,13 @@ UPDATE_FILE_NAME="${PLAT}"
 USB_DETECTION_DELAY=4
 
 KERNEL="\
-    fitImage \
+    Image \
     jh7110-starfive-visionfive-2-v1.3b.dtb \
 "
 
 BOOT="\
     fw_payload.bin \
-    boot.scr.uimg \
-    vf2_uEnv.txt \
+	grub-efi-bootriscv64.efi \
 "
 
 ROOTFS="rootfs.ext4.xz"

--- a/sources/meta-yoe/wic/yoe-visionfive2-sdimage.wks
+++ b/sources/meta-yoe/wic/yoe-visionfive2-sdimage.wks
@@ -14,12 +14,12 @@
 #
 part spl --source rawcopy --sourceparams="file=u-boot-spl.bin.normal.out" --part-name spl --offset 4096S --size 2M --part-type 2E54B353-1271-4842-806F-E436D6AF6985
 
-part uboot --source rawcopy --sourceparams="file=visionfive2_fw_payload.img" --part-name uboot --offset 8192S --size 4M --part-type 5B193300-FC78-40CD-8002-E86C45580B47
+part uboot --source rawcopy --sourceparams="file=u-boot.itb" --part-name uboot --offset 8192S --size 4M --part-type 5B193300-FC78-40CD-8002-E86C45580B47
 
-part /boot --source bootimg-partition --ondisk mmcblk --fstype=vfat --label boot --use-uuid --part-name boot --part-type EBD0A0A2-B9E5-4433-87C0-68B6B72699C7 --align 4096 --size 292M
+part /boot --source bootimg-efi --sourceparams="loader=grub-efi,dtb=jh7110-starfive-visionfive-2-v1.3b.dtb" --ondisk mmcblk --fstype=vfat --label boot --use-uuid --part-name boot  --align 4096 --size 292M
 # rootfs (3G)
 part /root --source rootfs --ondisk mmcblk --fstype=ext4 --part-name root --part-type 0FC63DAF-8483-4772-8E79-3D69D8477DE4 --active --label root --align 4096 --size 3072M
 # User data partition (1M)
 part /data --ondisk mmcblk --fstype=ext4 --label data --fixed-size 1 --align 4096 --fsoptions "x-systemd.growfs"
 
-bootloader  --ptable gpt
+bootloader  --ptable gpt --timeout 3 --append "console=ttyS0,115200 earlycon=sbi"


### PR DESCRIPTION
visionfive2 port in meta-riscv now uses upstream u-boot which looks for EFI supported boot. Adjust updater for that