### PR TITLE
cd: Disable builds for Jetson AGX orin

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -44,7 +44,7 @@ jobs:
         run: |
           /bin/bash -c ". ./envsetup.sh visionfive2 && bitbake yoe-installer-image"
           /bin/bash -c ". ./envsetup.sh rpi4-64 && bitbake yoe-installer-image yoe-kiosk-image"
-          /bin/bash -c ". ./envsetup.sh jetson-agx-orin-devkit && bitbake yoe-swupdate-image-tegra && cp build/tmp/deploy/images/p3737-0000-p3701-0005/yoe-swupdate-image-tegra-p3737-0000-p3701-0005.rootfs.swu deploy/"
+          #/bin/bash -c ". ./envsetup.sh jetson-agx-orin-devkit && bitbake yoe-swupdate-image-tegra && cp build/tmp/deploy/images/p3737-0000-p3701-0005/yoe-swupdate-image-tegra-p3737-0000-p3701-0005.rootfs.swu deploy/"
       - name: ver
         run: echo "ver=$(printf ' - ' && cat sources/meta-yoe/conf/distro/yoe.inc | grep 'DISTRO_CODENAME =' | cut -d' ' -f 3 )" >> $GITHUB_OUTPUT
         id: ver


### PR DESCRIPTION
There is a build error to handle still

NOTE: recipe yoe-swupdate-image-tegra-1.0-r0: task do_swuimage: Started
ERROR: yoe-swupdate-image-tegra-1.0-r0 do_swuimage: The file /usr/lib/libgio-2.0.so.0 is installed by both glib-2.0 and glib-2.0-initial, aborting
ERROR: Logfile of failure stored in: /home/khem/actions-runner-yoe/_work/yoe-distro/yoe-distro/build/tmp/work/p3737_0000_p3701_0005-yoe-linux/yoe-swupdate-image-tegra/1.0/temp/log.do_swuimage.840106
NOTE: recipe yoe-swupdate-image-tegra-1.0-r0: task do_swuimage: Failed

Dont enable it yet