### PR TITLE
jetson-agx-orin-devkit: Disable installing samples for now

### DIFF
--- a/conf/projects/jetson-agx-orin-devkit/config.conf
+++ b/conf/projects/jetson-agx-orin-devkit/config.conf
@@ -56,17 +56,15 @@ PREFERRED_PROVIDER_virtual/kernel = "linux-yocto"
 # Use gnu run time to keep cuda happy
 RUNTIME = "gnu"
 TC_CXX_RUNTIME = "gnu"
-CORE_IMAGE_EXTRA_INSTALL:append = " \
+CORE_IMAGE_EXTRA_INSTALL1:append = " \
   nvidia-drm-loadconf \
   cuda-libraries \
   ${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'vulkan-tools tegra-mmapi-samples mesa-demos l4t-graphics-demos-x11 nvgstapps argus-samples', '', d)} \
   ${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'vulkan-tools l4t-graphics-demos-wayland weston-examples', '', d)} \
   tensorrt-samples \
   tegra-tools-tegrastats \
-  cuda-samples \
   optee-nvsamples optee-test \
   cuda-samples \
-  opencv-samples opencv-apps \
   python3-opencv \
   python3-cuda \
   "


### PR DESCRIPTION
CI does not save 1.2G artifacts