### PR TITLE
yoe: fix typo in thin-lto DISTRO_FEATURE

### DIFF
--- a/sources/meta-yoe/conf/distro/yoe.inc
+++ b/sources/meta-yoe/conf/distro/yoe.inc
@@ -116,8 +116,8 @@ DISTRO_FEATURES:remove:linux-muslx32 = "ld-is-lld"
 DISTRO_FEATURES:remove:mipsarcho32 = "ld-is-lld"
 # qemu usermode segfaults the programs during glib-2.0-initial configure step
 DISTRO_FEATURES:remove:powerpc = "ld-is-lld"
-DISTRO_FEATURES_FILTER_NATIVE:append = " lto lto-thin"
-DISTRO_FEATURES_FILTER_NATIVESDK:append = " ld-is-lld lto lto-thin"
+DISTRO_FEATURES_FILTER_NATIVE:append = " lto thin-lto"
+DISTRO_FEATURES_FILTER_NATIVESDK:append = " ld-is-lld lto thin-lto"
 
 # Configure clang cross-compiler to use lld as default linker
 PACKAGECONFIG:append:pn-clang-native = " lld"


### PR DESCRIPTION
lto-thin seems to be a typo from thin-lto used in oe-core:

```
openembedded-core $ git grep lto-thin
openembedded-core $ git grep thin-lto
meta/conf/distro/include/lto.inc:# with clang thin-lto might be better for compile speed meta/conf/distro/include/lto.inc:LTO:toolchain-clang:class-target = "${@bb.utils.contains('DISTRO_FEATURES', 'thin-lto', '-flto=thin', '-flto -fuse-ld=lld', d)}" meta/conf/distro/include/lto.inc:LTO:toolchain-clang:class-nativesdk = "${@bb.utils.contains('DISTRO_FEATURES', 'thin-lto', '-flto=thin', '-flto -fuse-ld=lld', d)}"
meta/recipes-devtools/clang/clang_git.bb:                   ${@bb.utils.filter('DISTRO_FEATURES', 'lto thin-lto', d)} \
meta/recipes-devtools/clang/clang_git.bb:PACKAGECONFIG:remove:class-native = "lto thin-lto"
meta/recipes-devtools/clang/clang_git.bb:PACKAGECONFIG[thin-lto] = "-DLLVM_ENABLE_LTO=Thin -DLLVM_BINUTILS_INCDIR=${STAGING_INCDIR},,binutils,"
meta/recipes-devtools/clang/llvm_git.bb:PACKAGECONFIG ??= "eh rtti shared-libs ${@bb.utils.filter('DISTRO_FEATURES', 'lto thin-lto', d)}"
meta/recipes-devtools/clang/llvm_git.bb:PACKAGECONFIG:remove:class-native = "lto thin-lto"
meta/recipes-devtools/clang/llvm_git.bb:PACKAGECONFIG[thin-lto] = "-DLLVM_ENABLE_LTO=Thin -DLLVM_BINUTILS_INCDIR=${STAGING_INCDIR},,binutils,"
```

Fixes https://github.com/YoeDistro/yoe-distro/commit/e15c15a6bf50c1a716e5090219da682c91f019d9