### PR TITLE
Fix typo in meta-yoe layer.conf

### DIFF
--- a/sources/meta-yoe/conf/layer.conf
+++ b/sources/meta-yoe/conf/layer.conf
@@ -12,7 +12,7 @@ LAYERDEPENDS_meta-yoe = "core openembedded-layer networking-layer"
 
 BBFILES_DYNAMIC += " \
     openembedded-layer:${LAYERDIR}/dynamic-layers/openembedded-layer/*/*/*.bb \
-    openembedded-layer:${LAYERDIR}/dynamic-layers/openemvedded-layer/*/*/*.bbappend \
+    openembedded-layer:${LAYERDIR}/dynamic-layers/openembedded-layer/*/*/*.bbappend \
     networking-layer:${LAYERDIR}/dynamic-layers/networking-layer/*/*/*.bb \
     networking-layer:${LAYERDIR}/dynamic-layers/networking-layer/*/*/*.bbappend \
     qt5-layer:${LAYERDIR}/dynamic-layers/qt5-layer/*/*/*.bb \


### PR DESCRIPTION
This PR fixes a typo which prevents bbappend files from the openembedded-layer being included in the meta-yoe layer

Fixes #1091